### PR TITLE
COVP-172 Add newVirusTestsBySpecimenDate metric

### DIFF
--- a/app/landing/views.py
+++ b/app/landing/views.py
@@ -65,6 +65,12 @@ metrics = [
     'newVirusTestsByPublishDateRollingSum',
     'newVirusTestsByPublishDateDirection',
 
+    'newVirusTestsBySpecimenDate',
+    'newVirusTestsBySpecimenDateChange',
+    'newVirusTestsBySpecimenDateChangePercentage',
+    'newVirusTestsBySpecimenDateRollingSum',
+    'newVirusTestsBySpecimenDateDirection',
+
     'transmissionRateMin',
     'transmissionRateMax',
     'transmissionRateGrowthRateMin',

--- a/app/templates/html/components/easy_read/testing.html
+++ b/app/templates/html/components/easy_read/testing.html
@@ -1,7 +1,7 @@
-{% set latest = ("newVirusTestsByPublishDate" | get_data(data)) %}
-{% set change = ("newVirusTestsByPublishDateChange" | get_data(data)) %}
-{% set changePercentage = ("newVirusTestsByPublishDateChangePercentage" | get_data(data)) %}
-{% set rollingSum = ("newVirusTestsByPublishDateRollingSum" | get_data(data)) %}
+{% set latest = ("newVirusTestsBySpecimenDate" | get_data(data)) %}
+{% set change = ("newVirusTestsBySpecimenDateChange" | get_data(data)) %}
+{% set changePercentage = ("newVirusTestsBySpecimenDateChangePercentage" | get_data(data)) %}
+{% set rollingSum = ("newVirusTestsBySpecimenDateRollingSum" | get_data(data)) %}
 
 <h3 id="testing">Testing{% if latest.areaName != "United Kingdom" %} in {{ latest.areaName }}{% endif %}</h3>
 <p>Testing is where we do a test to see who has coronavirus. Some people are tested more than

--- a/app/templates/latex/sections/testing.tex
+++ b/app/templates/latex/sections/testing.tex
@@ -1,7 +1,7 @@
-{% set latest = ("newVirusTestsByPublishDate" | get_data(data)) %}
-{% set change = ("newVirusTestsByPublishDateChange" | get_data(data)) %}
-{% set changePercentage = ("newVirusTestsByPublishDateChangePercentage" | get_data(data)) %}
-{% set rollingSum = ("newVirusTestsByPublishDateRollingSum" | get_data(data)) %}
+{% set latest = ("newVirusTestsBySpecimenDate" | get_data(data)) %}
+{% set change = ("newVirusTestsBySpecimenDateChange" | get_data(data)) %}
+{% set changePercentage = ("newVirusTestsBySpecimenDateChangePercentage" | get_data(data)) %}
+{% set rollingSum = ("newVirusTestsBySpecimenDateRollingSum" | get_data(data)) %}
 
 \section{Testing{% if latest.areaName != "United Kingdom" %} in {{ latest.areaName | trim_area_name }}{% endif %} }
 


### PR DESCRIPTION
Added new metric to the list of metrics or replaced the old metric (_newVirusTestsByPublishDate_) by the new one.

This should fix it. I'd like it to be merged as it is to do some tests, as testing on my local machine might not work in the same way as when deployed to Azure.
I'm thinking about more changes anyway, this would be the first step to make it better.